### PR TITLE
Migrate 4242420263 peering with ca04 to a nearby pop (Paris -> NYC)

### DIFF
--- a/ca04/bird/conf.d/30-dn42-flap-fr.conf
+++ b/ca04/bird/conf.d/30-dn42-flap-fr.conf
@@ -1,4 +1,4 @@
 protocol bgp flap_fr from dnpeers {
-    neighbor fe80::903%wg0263flapfr as 4242420263;
+    neighbor fe80::263%wg0263flapfr as 4242420263;
     direct;
 }

--- a/ca04/systemd/network/30-dn42-flap-fr.netdev
+++ b/ca04/systemd/network/30-dn42-flap-fr.netdev
@@ -4,15 +4,15 @@
 [NetDev]
 Name=wg0263flapfr
 Kind=wireguard
-Description=WireGuard tunnel to AS4242420263 FlipFlap fr-par1
+Description=WireGuard tunnel to AS4242420263 FlipFlap us-nyc1
 
 [WireGuard]
 ListenPort=24210
 PrivateKeyFile=/etc/systemd/network/dn42.wgkey
 
 [WireGuardPeer]
-PublicKey=/kwo9FiQRtgNyhMARTW9SvyvXIN7I7LfoICTytHjfA4=
-Endpoint=fr-par1.flap42.eu:51903
+PublicKey=uY0GCV3adypvnCWtWcm10PCrJ/OWeplmgL64WWlqZFY=
+Endpoint=us-nyc1.flap42.eu:52007
 AllowedIPs=10.0.0.0/8
 AllowedIPs=172.20.0.0/14
 AllowedIPs=172.31.0.0/16

--- a/ca04/systemd/network/30-dn42-flap-fr.network
+++ b/ca04/systemd/network/30-dn42-flap-fr.network
@@ -10,7 +10,7 @@ RequiredFamilyForOnline=ipv6
 Group=4242
 
 [Network]
-Description=WireGuard tunnel to AS4242420263 FlipFlap fr-par1
+Description=WireGuard tunnel to AS4242420263 FlipFlap us-nyc1
 DHCP=no
 IPv6AcceptRA=false
 IPForward=yes
@@ -19,4 +19,4 @@ KeepConfiguration=yes
 
 [Address]
 Address=fe80::893/64
-Peer=fe80::903/64
+Peer=fe80::263/64


### PR DESCRIPTION
Related to #5, I have now a POP in NYC with a lower latency to `ca04`. 
I have updated our peering config files and also changed my link-local address.

Thanks for updating your config!